### PR TITLE
N64 Jet force Gemini preset

### DIFF
--- a/map/n64_jet_force_gemini.json
+++ b/map/n64_jet_force_gemini.json
@@ -1,0 +1,27 @@
+{
+    "name":"N64 Jet Force Gemini",
+    "desc":"Secondary left trigger is A, Secondary right trigger is B, Face Up/Down is C-Up, Face Left/Right is C-Down, Main left trigger is R, Main right trigger is Z",
+    "map":[
+        ["PAD_LX_LEFT",  "PAD_LX_LEFT",  0, 100, 50, 135, 0, 0, 0],
+        ["PAD_LX_RIGHT", "PAD_LX_RIGHT", 0, 100, 50, 135, 0, 0, 0],
+        ["PAD_LY_DOWN",  "PAD_LY_DOWN",  0, 100, 50, 135, 0, 0, 0],
+        ["PAD_LY_UP",    "PAD_LY_UP",    0, 100, 50, 135, 0, 0, 0],
+        ["PAD_RX_LEFT",  "PAD_RX_LEFT",  0, 100, 50, 135, 0, 0, 0],
+        ["PAD_RX_RIGHT", "PAD_RX_RIGHT", 0, 100, 50, 135, 0, 0, 0],
+        ["PAD_RY_DOWN",  "PAD_RY_DOWN",  0, 100, 50, 135, 0, 0, 0],
+        ["PAD_RY_UP",    "PAD_RY_UP",    0, 100, 50, 135, 0, 0, 0],
+        ["PAD_LD_LEFT",  "PAD_LD_LEFT",  0, 100, 50, 135, 0, 0, 0],
+        ["PAD_LD_RIGHT", "PAD_LD_RIGHT", 0, 100, 50, 135, 0, 0, 0],
+        ["PAD_LD_DOWN",  "PAD_LD_DOWN",  0, 100, 50, 135, 0, 0, 0],
+        ["PAD_LD_UP",    "PAD_LD_UP",    0, 100, 50, 135, 0, 0, 0],
+        ["PAD_RB_LEFT",  "PAD_RY_DOWN",  0, 100, 50, 135, 0, 0, 0],
+        ["PAD_RB_RIGHT", "PAD_RY_DOWN",  0, 100, 50, 135, 0, 0, 0],
+        ["PAD_RB_DOWN",  "PAD_RY_UP",    0, 100, 50, 135, 0, 0, 0],
+        ["PAD_RB_UP",    "PAD_RY_UP",    0, 100, 50, 135, 0, 0, 0],
+        ["PAD_MM",       "PAD_MM",       0, 100, 50, 135, 0, 0, 0],
+        ["PAD_LM",       "PAD_RS",       0, 100, 50, 135, 0, 0, 0],
+        ["PAD_LS",       "PAD_RB_LEFT",  0, 100, 50, 135, 0, 0, 0],
+        ["PAD_RM",       "PAD_RM",       0, 100, 50, 135, 0, 0, 0],
+        ["PAD_RS",       "PAD_RB_DOWN",  0, 100, 50, 135, 0, 0, 0]
+    ]
+}


### PR DESCRIPTION
right bumper is A, left bumper is B, A/Y is now c-up, X/B is now c-down, left trigger is R, right trigger is Z

this allows for more intuitive jumping (on A), weapon switching (bumpers), hold LT to aim and RT to shoot.

menus are maneuvered with left bumper for B and right bumper for A